### PR TITLE
Control runmode dropdown

### DIFF
--- a/public/javascripts/control_script.js
+++ b/public/javascripts/control_script.js
@@ -17,7 +17,7 @@ function PopulateOptionsLists(callback){
 function PullServerData(){
   $.getJSON("control/get_control_doc", function(doc){
     ["stop_after", "comment"].forEach( (att) => $(`#${att}`).val(doc[att]));
-    $(`#mode`).filter(function() {return this.value===doc.mode;}).prop('selected', true);
+    $(`#mode option`).filter(function() {return this.value===doc.mode;}).prop('selected', true);
     $(`#user`).val(doc.user);
     ['active', 'softstop'].forEach(att => $(`#${att}`).bootstrapToggle(doc[att] == 'true' ? 'on' : 'off'));
     document.page_ready = true;

--- a/routes/control.js
+++ b/routes/control.js
@@ -12,7 +12,7 @@ router.get('/', common.ensureAuthenticated, function(req, res) {
 
 router.get('/modes', common.ensureAuthenticated, function(req, res){
   var collection = req.db.get("options");
-  collection.find({}, {fields: "name description -_id"})
+  collection.find({detector: {$ne: 'include'}}, {fields: "name description -_id"})
       .then((docs) => res.json(docs))
       .catch((err) => {
         console.log(err.message);


### PR DESCRIPTION
On the control side, don't show run modes that are detector: include in dropdown. Also fixes problem where the current runmode wasn't selected correctly. 